### PR TITLE
[JMS-SPEC-161] serialVersionUID of JMSException has changed from JMS 1.1 to JMS 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>10</version>
+    <version>24</version>
   </parent>
 
   <groupId>org.jboss.spec.javax.jms</groupId>
@@ -89,6 +89,7 @@
             <Specification-Title>JSR-000343: Java(TM) Message Service (JMS) 2.0 API</Specification-Title>
             <Specification-Vendor>Oracle</Specification-Vendor>
             <Specification-Version>2.0</Specification-Version>
+            <Implementation-Version>2.0.1</Implementation-Version>
             <!-- Set the package version to match the spec version -->
             <Export-Package>
               javax.jms*;version=2.0
@@ -116,6 +117,7 @@
               <Specification-Title>JSR-000343: Java(TM) Message Service (JMS) 2.0 API</Specification-Title>
               <Specification-Vendor>Oracle</Specification-Vendor>
               <Specification-Version>2.0</Specification-Version>
+              <Implementation-Version>2.0.1</Implementation-Version>
             </manifestEntries>
           </archive>
         </configuration>

--- a/src/main/java/javax/jms/IllegalStateException.java
+++ b/src/main/java/javax/jms/IllegalStateException.java
@@ -56,6 +56,11 @@ package javax.jms;
 
 public class IllegalStateException extends JMSException {
 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -6850763061112244487L;
+
   /** Constructs an {@code IllegalStateException} with the specified reason
    *  and error code.
    *

--- a/src/main/java/javax/jms/IllegalStateRuntimeException.java
+++ b/src/main/java/javax/jms/IllegalStateRuntimeException.java
@@ -54,6 +54,11 @@ package javax.jms;
 public class IllegalStateRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 6838714637432837899L;
+
+	/**
 	 * Constructs a {@code IllegalStateRuntimeException} with the specified detail message
 	 * 
 	 * @param detailMessage

--- a/src/main/java/javax/jms/InvalidClientIDException.java
+++ b/src/main/java/javax/jms/InvalidClientIDException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class InvalidClientIDException extends JMSException {
 
-  /** Constructs an {@code InvalidClientIDException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = 2410181719763491702L;
+
+  /** Constructs an {@code InvalidClientIDException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/InvalidClientIDRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidClientIDRuntimeException.java
@@ -52,7 +52,12 @@ package javax.jms;
  **/
 
 public class InvalidClientIDRuntimeException extends JMSRuntimeException {
-	
+
+	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = -1997236208457896631L;
+
 	/**
 	 * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message
 	 * 

--- a/src/main/java/javax/jms/InvalidDestinationException.java
+++ b/src/main/java/javax/jms/InvalidDestinationException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class InvalidDestinationException extends JMSException {
 
-  /** Constructs an {@code InvalidDestinationException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -8588063794606036755L;
+
+  /** Constructs an {@code InvalidDestinationException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/InvalidDestinationRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidDestinationRuntimeException.java
@@ -52,6 +52,11 @@ package javax.jms;
 public class InvalidDestinationRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 2765276997130843763L;
+
+	/**
 	 * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message
 	 * 
 	 * @param detailMessage

--- a/src/main/java/javax/jms/InvalidSelectorException.java
+++ b/src/main/java/javax/jms/InvalidSelectorException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class InvalidSelectorException extends JMSException {
 
-  /** Constructs an {@code InvalidSelectorException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID =  6223038613086963841L;
+
+  /** Constructs an {@code InvalidSelectorException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/InvalidSelectorRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidSelectorRuntimeException.java
@@ -53,6 +53,11 @@ package javax.jms;
 public class InvalidSelectorRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 1974783946275023548L;
+
+	/**
 	 * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message
 	 * 
 	 * @param detailMessage

--- a/src/main/java/javax/jms/JMSException.java
+++ b/src/main/java/javax/jms/JMSException.java
@@ -61,6 +61,11 @@ package javax.jms;
 
 public class JMSException extends Exception {
 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = 8951994251593378324L;
+
   /** Vendor-specific error code.
   **/
   private String errorCode;

--- a/src/main/java/javax/jms/JMSRuntimeException.java
+++ b/src/main/java/javax/jms/JMSRuntimeException.java
@@ -55,6 +55,11 @@ package javax.jms;
 public class JMSRuntimeException extends RuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+	 */
+	private static final long serialVersionUID = -5204332229969809982L;
+
+	/**
 	 * Provider-specific error code.
 	 **/
 	private String errorCode=null;

--- a/src/main/java/javax/jms/JMSSecurityException.java
+++ b/src/main/java/javax/jms/JMSSecurityException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class JMSSecurityException extends JMSException {
 
-  /** Constructs a {@code JMSSecurityException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -7512859695190450217L;
+
+  /** Constructs a {@code JMSSecurityException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/JMSSecurityRuntimeException.java
+++ b/src/main/java/javax/jms/JMSSecurityRuntimeException.java
@@ -52,7 +52,12 @@ package javax.jms;
  **/
 
 public class JMSSecurityRuntimeException extends JMSRuntimeException {
-	
+
+	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 1020149469192845616L;
+
 	/**
 	 * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message
 	 * 

--- a/src/main/java/javax/jms/MessageEOFException.java
+++ b/src/main/java/javax/jms/MessageEOFException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class MessageEOFException extends JMSException {
 
-  /** Constructs a {@code MessageEOFException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -4829621000056590895L;
+
+  /** Constructs a {@code MessageEOFException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/MessageFormatException.java
+++ b/src/main/java/javax/jms/MessageFormatException.java
@@ -60,7 +60,12 @@ package javax.jms;
 
 public class MessageFormatException extends JMSException {
 
-  /** Constructs a {@code MessageFormatException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -3642297253594750138L;
+
+  /** Constructs a {@code MessageFormatException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/MessageFormatRuntimeException.java
+++ b/src/main/java/javax/jms/MessageFormatRuntimeException.java
@@ -58,6 +58,11 @@ package javax.jms;
 public class MessageFormatRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 416918643772467720L;
+
+	/**
 	 * Constructs a {@code MessageFormatRuntimeException} with the specified detail message
 	 * 
 	 * @param detailMessage

--- a/src/main/java/javax/jms/MessageNotReadableException.java
+++ b/src/main/java/javax/jms/MessageNotReadableException.java
@@ -51,7 +51,12 @@ package javax.jms;
 
 public class MessageNotReadableException extends JMSException {
 
-  /** Constructs a {@code MessageNotReadableException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = 8044835867550650748L;
+
+  /** Constructs a {@code MessageNotReadableException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/MessageNotWriteableException.java
+++ b/src/main/java/javax/jms/MessageNotWriteableException.java
@@ -51,7 +51,12 @@ package javax.jms;
 
 public class MessageNotWriteableException extends JMSException {
 
-  /** Constructs a {@code MessageNotWriteableException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -4241931174711518830L;
+
+  /** Constructs a {@code MessageNotWriteableException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/MessageNotWriteableRuntimeException.java
+++ b/src/main/java/javax/jms/MessageNotWriteableRuntimeException.java
@@ -53,6 +53,11 @@ package javax.jms;
 public class MessageNotWriteableRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 6075922984499850209L;
+
+	/**
 	 * Constructs a {@code MessageNotWriteableRuntimeException} with the
 	 * specified reason and error code.
 	 * 

--- a/src/main/java/javax/jms/ResourceAllocationException.java
+++ b/src/main/java/javax/jms/ResourceAllocationException.java
@@ -54,7 +54,12 @@ package javax.jms;
 
 public class ResourceAllocationException extends JMSException {
 
-  /** Constructs a {@code ResourceAllocationException} with the specified 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -1172695755360706776L;
+
+  /** Constructs a {@code ResourceAllocationException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/ResourceAllocationRuntimeException.java
+++ b/src/main/java/javax/jms/ResourceAllocationRuntimeException.java
@@ -54,7 +54,12 @@ package javax.jms;
 
 public class ResourceAllocationRuntimeException extends JMSRuntimeException {
 
-  /** Constructs a {@code ResourceAllocationRuntimeException} with the specified 
+	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = -1306897975610715374L;
+
+	/** Constructs a {@code ResourceAllocationRuntimeException} with the specified
    *  reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/TransactionInProgressException.java
+++ b/src/main/java/javax/jms/TransactionInProgressException.java
@@ -55,7 +55,12 @@ package javax.jms;
 
 public class TransactionInProgressException extends JMSException {
 
-  /** Constructs a {@code TransactionInProgressException} with the 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = -5611340150426335231L;
+
+  /** Constructs a {@code TransactionInProgressException} with the
    *  specified reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/TransactionInProgressRuntimeException.java
+++ b/src/main/java/javax/jms/TransactionInProgressRuntimeException.java
@@ -53,6 +53,11 @@ package javax.jms;
 public class TransactionInProgressRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = -916492460069513065L;
+
+	/**
 	 * Constructs a {@code TransactionInProgressRuntimeException} with the
 	 * specified detail message
 	 * 

--- a/src/main/java/javax/jms/TransactionRolledBackException.java
+++ b/src/main/java/javax/jms/TransactionRolledBackException.java
@@ -52,7 +52,12 @@ package javax.jms;
 
 public class TransactionRolledBackException extends JMSException {
 
-  /** Constructs a {@code TransactionRolledBackException} with the 
+  /**
+   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+   */
+  private static final long serialVersionUID = 9157976009672865857L;
+
+  /** Constructs a {@code TransactionRolledBackException} with the
    *  specified reason and error code.
    *
    *  @param  reason        a description of the exception

--- a/src/main/java/javax/jms/TransactionRolledBackRuntimeException.java
+++ b/src/main/java/javax/jms/TransactionRolledBackRuntimeException.java
@@ -51,6 +51,11 @@ package javax.jms;
 public class TransactionRolledBackRuntimeException extends JMSRuntimeException {
 
 	/**
+	 * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+	 */
+	private static final long serialVersionUID = 2157965166257651703L;
+
+	/**
 	 * Constructs a {@code TransactionRolledBackRuntimeException} with the
 	 * specified detail message
 	 * 


### PR DESCRIPTION
For all exceptions that were defined prior to JMS 2.0
(IllegalStateException, InvalidClientIDException,
InvalidDestinationException, InvalidSelectorException, JMSException,
JMSSecurityException, MessageEOFException, MessageFormatException,
MessageNotReadableException, MessageNotWriteableException,
ResourceAllocationException, TransactionInProgressException,
TransactionRolledBackException), an explicit serialVersionUID has been
set which matches the implicit serialVersionUID of the JMS 1.1
implementation.

For all exceptions that were added in JMS 2.0
(IllegalStateRuntimeException, InvalidClientIDRuntimeException,
InvalidDestinationRuntimeException, InvalidSelectorRuntimeException,
JMSRuntimeException, JMSSecurityRuntimeException,
MessageFormatRuntimeException, MessageNotWriteableRuntimeException,
ResourceAllocationRuntimeException,
TransactionInProgressRuntimeException,
TransactionRolledBackRuntimeException), an explicit serialVersionUID has
been set which matches the implicit serialVersionUID of the previous JMS
2.0 implementation.

Update Implementation-Version to 2.0.1.

Spec issue: https://github.com/javaee/jms-spec/issues/161